### PR TITLE
Feat/territory generation

### DIFF
--- a/backend/src/App.cs
+++ b/backend/src/App.cs
@@ -52,6 +52,8 @@ catch (Exception ex)
     Console.WriteLine("DbQuery error: " + ex.Message);
 }
 
+await app.RunStartupUtils();
+
 app.Run();
 
 

--- a/backend/src/DbQuery.cs
+++ b/backend/src/DbQuery.cs
@@ -221,19 +221,6 @@ public static class DbQuery
             command.ExecuteNonQuery();
         }
 
-        // Seed Territories
-        command.CommandText = "SELECT COUNT(*) FROM Territories";
-        if (Convert.ToInt32(command.ExecuteScalar()) == 0)
-        {
-            var ContinentData = @"
-                INSERT INTO Territories (name, NorthAdjacentId, SouthAdjacentId, WestAdjacentId, EastAdjacentId, Continentid) VALUES
-                ('Halmstad', 2, -1, -1, -1, 1),
-                ('Stockstad', -1, 1, -1, -1, 1);
-            ";
-            command.CommandText = ContinentData;
-            command.ExecuteNonQuery();
-        }
-
         // Seed the rest of the tables/views here. 
     }
 

--- a/backend/src/StartupUtils.cs
+++ b/backend/src/StartupUtils.cs
@@ -7,8 +7,11 @@ public static class StartupUtils
     public static async Task RunStartupUtils(this WebApplication app)
     {
         using var scope = app.Services.CreateScope();
-
         var repo = scope.ServiceProvider.GetRequiredService<ITerritoryRepository>();
-        await TerritoryGeneration.AddTerritories(1, 1, repo, CancellationToken.None);
+        //Checks of territories are already added before creating
+        var territory0 = await repo.GetTerritoryByIdAsync(1, CancellationToken.None);
+        if (territory0==null) {
+            await TerritoryGeneration.AddTerritories(7, 7, repo, CancellationToken.None);
+        }
     }
 }

--- a/backend/src/StartupUtils.cs
+++ b/backend/src/StartupUtils.cs
@@ -1,0 +1,14 @@
+namespace TddGame;
+
+
+public static class StartupUtils
+{
+    //Sets up services to be able to call util methods outside endpoints
+    public static async Task RunStartupUtils(this WebApplication app)
+    {
+        using var scope = app.Services.CreateScope();
+
+        var repo = scope.ServiceProvider.GetRequiredService<ITerritoryRepository>();
+        await TerritoryGeneration.AddTerritories(1, 1, repo, CancellationToken.None);
+    }
+}

--- a/backend/src/Utils/TerritoryGeneration.cs
+++ b/backend/src/Utils/TerritoryGeneration.cs
@@ -1,6 +1,11 @@
 namespace TddGame;
 
+using Microsoft.AspNetCore.Http.HttpResults;
+
 public static class TerritoryGeneration
 {
-    
+    public static async Task AddTerritories(int width, int height, ITerritoryRepository repo, CancellationToken ct)
+    {
+        await repo.CreateTerritoryAsync("Michigan", -1, -1, -1, -1, 1, ct);
+    }
 }

--- a/backend/src/Utils/TerritoryGeneration.cs
+++ b/backend/src/Utils/TerritoryGeneration.cs
@@ -4,8 +4,27 @@ using Microsoft.AspNetCore.Http.HttpResults;
 
 public static class TerritoryGeneration
 {
-    public static async Task AddTerritories(int width, int height, ITerritoryRepository repo, CancellationToken ct)
+    public static async Task<IResult> AddTerritories(int width, int height, ITerritoryRepository repo, CancellationToken ct)
     {
-        await repo.CreateTerritoryAsync("Michigan", -1, -1, -1, -1, 1, ct);
+        var territories = new List<TerritoryDto>();
+        for (int y = 0; y < height; y++)
+        {
+            for (int x = 0; x < width; x++)
+            {
+                string name = $"Territory_{x}_{y}";
+                int north = -1;
+                int south = -1;
+                int west = x-1;
+                int east = -1;
+
+                if (y != height) { north = y-1; }
+                if (y < height - 1) { south = y + 1; }
+                if (x != width) { west = x-1; }
+                if (x < width - 1) { east = x + 1; }
+                
+                territories.Add(await repo.CreateTerritoryAsync(name, north, south, west, east, 1, ct));
+            }
+        }
+        return TypedResults.Ok(territories);
     }
 }

--- a/backend/src/Utils/TerritoryGeneration.cs
+++ b/backend/src/Utils/TerritoryGeneration.cs
@@ -1,0 +1,6 @@
+namespace TddGame;
+
+public static class TerritoryGeneration
+{
+    
+}


### PR DESCRIPTION
Add territory generation

Reset database and verify that 49 connected territories are added to the Territories table

Decided to not add any specific Xunit tests to the util method, likely cleaner to test the results elsewhere.